### PR TITLE
Modification in AT command to delete all the SMSs

### DIFF
--- a/src/TinyGsmClientSIM800.h
+++ b/src/TinyGsmClientSIM800.h
@@ -713,7 +713,7 @@ public:
 
   bool deleteAllSMS()
   {
-	  sendAT(GF("+CMGD=0,4"));
+	  sendAT(GF("+CMGD=1,4"));
 	  return waitResponse() == 1;
   }
 

--- a/src/TinyGsmClientSIM800.h
+++ b/src/TinyGsmClientSIM800.h
@@ -713,7 +713,7 @@ public:
 
   bool deleteAllSMS()
   {
-	  sendAT(GF("+CMGD=4"));
+	  sendAT(GF("+CMGD=0,4"));
 	  return waitResponse() == 1;
   }
 


### PR DESCRIPTION
According to the datasheet, in order to delete all SMS's the correct command has the syntax "AT+CMGD=x,4", where the index 'x' is ignored.